### PR TITLE
Public repository url for the libjson-rpc submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/libjson-rpc-cpp"]
 	path = vendor/libjson-rpc-cpp
-	url = git@github.com:cinemast/libjson-rpc-cpp.git
+	url = https://github.com/cinemast/libjson-rpc-cpp.git


### PR DESCRIPTION
The url of the submodule should be the https one,
because the current one doesn't allow to clone it,
if you don't have an account on GitHub
(or no configured access on your computer).

It should not break anything for users who have already cloned the repo.
