### PR TITLE
Remove the init method and move its content to the constructor.

### DIFF
--- a/src/mage.cpp
+++ b/src/mage.cpp
@@ -15,12 +15,8 @@ namespace mage
 
 	RPC::~RPC()
 	{
-		if (jsonRpcClient) {
-			delete jsonRpcClient;
-		}
-		if (httpClient) {
-			delete httpClient;
-		}
+		delete jsonRpcClient;
+		delete httpClient;
 	}
 
 	Json::Value RPC::Call(const std::string &name, const Json::Value &params)

--- a/src/mage.cpp
+++ b/src/mage.cpp
@@ -1,7 +1,6 @@
 #include "mage.h"
 
 using namespace jsonrpc;
-using namespace std;
 
 namespace mage
 {
@@ -9,20 +8,19 @@ namespace mage
 	RPC::RPC(std::string mageApplication, std::string mageDomain, std::string mageProtocol) :
 		protocol(mageProtocol), domain(mageDomain), application(mageApplication)
 	{
-		init();
+		buildConnector();
+		httpClient = new HttpClient(url);
+		jsonRpcClient = new Client(httpClient);
 	}
 
 	RPC::~RPC()
 	{
-		delete jsonRpcClient;
-		delete httpClient;
-	}
-
-	void RPC::init()
-	{
-		buildConnector();
-		httpClient = new HttpClient(url);
-		jsonRpcClient = new Client(httpClient);
+		if (jsonRpcClient) {
+			delete jsonRpcClient;
+		}
+		if (httpClient) {
+			delete httpClient;
+		}
 	}
 
 	Json::Value RPC::Call(const std::string &name, const Json::Value &params)
@@ -48,7 +46,7 @@ namespace mage
 	}
 
 	void RPC::RegisterCallback(const std::string &eventName, std::function<void(Json::Value)> callback) {
-		cout << "Registering callback for event:" << eventName << endl;
+		std::cout << "Registering callback for event:" << eventName << std::endl;
 	}
 
 	void RPC::SetDomain(const std::string mageDomain) {

--- a/src/mage.h
+++ b/src/mage.h
@@ -28,7 +28,6 @@ namespace mage
 			void ClearSession();
 
 		private:
-			void init();
 			void buildConnector();
 
 			std::string protocol;
@@ -38,7 +37,7 @@ namespace mage
 			std::string url;
 
 			HttpClient *httpClient;
-			Client *jsonRpcClient;
+			Client     *jsonRpcClient;
 	};
 
 } /* namespace mage */


### PR DESCRIPTION
Using the init method outside of the constructor will lead to a memory
leak, because the 2 pointers will not be deleted.

As the method is not required, I dropped it.
