### PR TITLE
Delete httpClient only once.

### DIFF
--- a/src/mage.cpp
+++ b/src/mage.cpp
@@ -15,7 +15,6 @@ namespace mage
 	RPC::~RPC()
 	{
 		delete jsonRpcClient;
-		delete httpClient;
 	}
 
 	void RPC::init()


### PR DESCRIPTION
httpClient is deleted in jsonrpc::Client destructor. So, mage::RPC does not need to delete httpClient in it's destructor.
