### PR TITLE
Fix ambiguous declaration.

### DIFF
--- a/src/mage.h
+++ b/src/mage.h
@@ -6,8 +6,6 @@
 #include <functional>
 #include <jsonrpc/rpc.h>
 
-using namespace jsonrpc;
-
 namespace mage
 {
 	class RPC
@@ -34,8 +32,8 @@ namespace mage
 			std::string domain;
 			std::string application;
 
-			HttpClient *httpClient;
-			Client     *jsonRpcClient;
+			jsonrpc::HttpClient *httpClient;
+			jsonrpc::Client     *jsonRpcClient;
 	};
 
 } /* namespace mage */


### PR DESCRIPTION
Cocos2d-x also have HttpClient class. When integrating with cocos2d-x, compiler can't determine exact class type.
