### PR TITLE
[Android] src/mage.cpp was renamed

### DIFF
--- a/platforms/android/jni/Android.mk
+++ b/platforms/android/jni/Android.mk
@@ -9,7 +9,7 @@ MAGE_SRC_DIR := $(LOCAL_PATH)/../../../src
 LIBJSONRPC_SRC_DIR := $(LOCAL_PATH)/../../../vendor/libjson-rpc-cpp/src
 
 LOCAL_SRC_FILES := $(MAGE_SRC_DIR)/exceptions.cpp \
-				   $(MAGE_SRC_DIR)/mage.cpp \
+				   $(MAGE_SRC_DIR)/rpc.cpp \
 				   $(LIBJSONRPC_SRC_DIR)/jsonrpc/client.cpp \
 				   $(LIBJSONRPC_SRC_DIR)/jsonrpc/clientconnector.cpp \
 				   $(LIBJSONRPC_SRC_DIR)/jsonrpc/connectors/mongoose.c \


### PR DESCRIPTION
With https://github.com/mage/mage-sdk-cpp/commit/d64af635e698cb0c67de7e9d7b67c961b12bbc32 `src/mage.cpp` was renamed.
